### PR TITLE
Stabilize raw acquisition utilities

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,36 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.9"
+          - "3.11"
+          - "3.12"
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements*.txt
+      - name: Install test dependencies
+        run: python -m pip install --requirement requirements-dev.txt
+      - name: Run tests
+        env:
+          MPLBACKEND: Agg
+          PYTHONDONTWRITEBYTECODE: "1"
+        run: python -m pytest -p no:cacheprovider

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 .venv/
 venv/
 *.egg-info/
+.pytest_cache/
 *.log
 *.dat
 *.raw

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,21 @@
-MIT License - WVU Radio Astronomy Instrumentation Lab (WVURAIL)
-Permission is hereby granted, free of charge, to any person obtaining a copy...
+MIT License
+
+Copyright (c) 2022-2026 rawice contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # rawice
 
-Read RAW ADC snapshots from ICE boards.
+Read RAW ADC snapshots from ICE boards and produce clock-stability and raw
+acquisition diagnostics.
 
 `rawice.py` is the library. The notebooks in this directory are the analyses
 built on it, and each one starts with
@@ -23,19 +24,105 @@ location to `sys.path` in each one.
 | `raw_acq_diagnostics/` | diagnostic plots for raw acquisitions, plus a CLI that can mail the results — Bridget Andersen, 2024 |
 | `*.ipynb` | per-session analyses, named by date and frame rate |
 
-## Running it
+## Install dependencies
+
+Use a virtual environment. The core reader and plotting library require:
 
 ```bash
-pip install numpy scipy matplotlib h5py allantools jupyter
+python -m pip install --requirement requirements.txt
+```
+
+For the historical notebooks and the optional Allan-deviation method:
+
+```bash
+python -m pip install --requirement requirements-notebooks.txt
 jupyter notebook
 ```
 
 `allantools` is imported lazily, inside the one method that computes an
 overlapping Allan deviation, so everything else works without it.
 
-The diagnostics CLI has its own dependencies:
+The separate diagnostics module and CLI require their full dependency set:
 
 ```bash
-pip install click python-dateutil pytz
+python -m pip install --requirement requirements-diagnostics.txt
 python3 raw_acq_diagnostics/raw_acq_cli.py --help
 ```
+
+## Core usage
+
+The coordinate order is `[crate, slot, input]`:
+
+```python
+from rawice import raw_acq
+
+acquisition = raw_acq("/path/to/acquisition.h5")
+single_input = acquisition.check_input([0, 1, 2])
+single_input.inspect_maser()
+```
+
+Acquisition arrays now belong to each `raw_acq` instance. For compatibility
+with existing notebooks, class-level access such as `raw_acq.timestream` and
+`raw_acq.check_input(...)` still refers to the most recently loaded file. New
+code should use the instance form so loading another file cannot change which
+data an analysis helper reads.
+
+Expected HDF5 inputs contain `crate`, `slot`, `adc_input`, `timestamp`, and
+`timestream` datasets, plus `index_map/timestream`. The `timestamp` records
+must contain `fpga_count` and Unix `ctime` fields.
+
+## Diagnostics CLI
+
+Loading diagnostics by date requires the raw acquisition root. Pass it on the
+command line or set `RAW_ACQ_DIR`:
+
+```bash
+python3 raw_acq_diagnostics/raw_acq_cli.py plot-summed-spectrum \
+  --raw-acq-dir /path/to/raw_acq \
+  --plot-dir .
+```
+
+Email delivery is optional. Supply credentials through
+`RAW_ACQ_EMAIL_USERNAME` and `RAW_ACQ_EMAIL_APP_PASSWORD`; do not place an app
+password in source code.
+
+## Tests
+
+The tests use small synthetic HDF5 files and do not require observatory data:
+
+```bash
+python -m pip install --requirement requirements-dev.txt
+PYTHONDONTWRITEBYTECODE=1 python -m pytest -s -p no:cacheprovider
+```
+
+## Current limitations
+
+- No observatory acquisition data is distributed here. Several historical
+  notebooks contain site-specific `/home/observer/...` paths and saved output;
+  they are research records, not automated tests.
+- Some notebooks use historical kernels (`py37mkl`, `py38`, or `chimefrb`) and
+  may need a compatible environment or manual path updates.
+- The legacy curve-fit `tau_shift` calculation applies the final fitted clock
+  stability to every fitted phase. That scientific convention is preserved
+  pending domain validation rather than changed during maintenance.
+- Date-based diagnostics assume the existing `*_gbo_rawadc*` directory naming
+  convention. Direct filename loading does not require `raw_acq_dir`.
+
+## Downstream snapshot
+
+[`WVURAIL/DigitalNoiseSource`](https://github.com/WVURAIL/DigitalNoiseSource)
+vendors `rawice.py` from commit
+[`d6e3c3c0b650c978962921d44e5a54aaf6967583`](https://github.com/WVURAIL/rawice/commit/d6e3c3c0b650c978962921d44e5a54aaf6967583)
+for its recorded PEACC analysis. That snapshot is intentionally pinned; current
+`rawice.py` changes must be reviewed against the downstream notebooks and must
+not be copied or merged automatically.
+
+## Contributors and license
+
+Git history records contributions to `rawice.py` by Pranav Sanghavi and Audrey
+Zinn, and attributes the original diagnostics module to Bridget Andersen. It
+preserves the available attribution record.
+
+This repository is distributed under the [MIT License](LICENSE). The complete
+standard text replaces the truncated placeholder added during 2026
+maintenance and retains attribution to the rawice contributors.

--- a/raw_acq_diagnostics/raw_acq_cli.py
+++ b/raw_acq_diagnostics/raw_acq_cli.py
@@ -1,6 +1,9 @@
 import dateutil, pytz, datetime
 import numpy as np
-import raw_acq_diagnostics as rad
+if __package__:
+    from . import raw_acq_diagnostics as rad
+else:  # Support direct execution from this directory.
+    import raw_acq_diagnostics as rad
 import click
 import smtplib
 import os
@@ -11,9 +14,9 @@ from email.mime.text import MIMEText
 from email.utils import COMMASPACE, formatdate
 
 
-# Set email username and app password
-username = None
-app_password = None
+# Optional email credentials. Do not store app passwords in source control.
+username = os.environ.get("RAW_ACQ_EMAIL_USERNAME")
+app_password = os.environ.get("RAW_ACQ_EMAIL_APP_PASSWORD")
 
 def send_email(subject, body, sender, recipients, password, files=None):
     msg = MIMEMultipart()
@@ -150,8 +153,15 @@ def cli():
     help="Whether to save the plot to the directory indicated by plot_dir (current directory by default)",
 )
 @click.option(
+    "--raw-acq-dir",
+    type=click.Path(exists=True, file_okay=False, readable=True, resolve_path=True),
+    envvar="RAW_ACQ_DIR",
+    required=True,
+    help="Directory containing raw acquisition run directories (or set RAW_ACQ_DIR).",
+)
+@click.option(
     "--plot-dir",
-    type=click.Path(exists=False, readable=True, resolve_path=True),
+    type=click.Path(exists=True, file_okay=False, writable=True, resolve_path=True),
     required=False,
     default='./',
     help="The directory that the plot will be saved to if save_plot=True (current directory by default)",
@@ -173,30 +183,38 @@ def plot_summed_spectrum(
         ds_freq_factor,
         site,
         save_plot,
+        raw_acq_dir,
         plot_dir,
         email,
 ):
-    est = pytz.timezone('US/Eastern')
     utc = pytz.utc
     
     # If start_time and end_time are not provided, select the last 24 hours
-    if start_time == "" or end_time == "":
-        end_time_utc = (datetime.datetime.utcnow() - datetime.timedelta(minutes=5)).astimezone(utc)
+    if start_time == "" and end_time == "":
+        end_time_utc = datetime.datetime.now(tz=utc) - datetime.timedelta(minutes=5)
         start_time_utc = (end_time_utc - datetime.timedelta(hours=24)).astimezone(utc)
+    elif start_time == "" or end_time == "":
+        raise click.BadParameter(
+            "provide both --start-time and --end-time, or omit both",
+            param_hint="--start-time/--end-time",
+        )
     else:
         # Else, check that start_time and end_time are formatted properly
         try:
             start_time_dt = datetime.datetime.strptime(start_time, "%Y-%m-%d %H:%M:%S")
             end_time_dt = datetime.datetime.strptime(end_time, "%Y-%m-%d %H:%M:%S")
+        except ValueError as error:
+            raise click.BadParameter(
+                "times must use YYYY-MM-DD HH:mm:ss",
+                param_hint="--start-time/--end-time",
+            ) from error
 
-            # Turn the strings into timezone-aware UTC datetimes
-            start_time_et = est.localize(start_time_dt)
-            end_time_et = est.localize(end_time_dt)
-            start_time_utc = start_time_et.astimezone(utc)
-            end_time_utc = end_time_et.astimezone(utc)
-        except Exception as e:
-            print("Exception encountered: {}".format(e))
-            exit()
+        # Turn the strings into timezone-aware UTC datetimes.
+        est = pytz.timezone('US/Eastern')
+        start_time_et = est.localize(start_time_dt)
+        end_time_et = est.localize(end_time_dt)
+        start_time_utc = start_time_et.astimezone(utc)
+        end_time_utc = end_time_et.astimezone(utc)
 
     dates = np.array([
         start_time_utc,
@@ -211,6 +229,7 @@ def plot_summed_spectrum(
     raw_acq = rad.RawAcq(
         dates=dates,
         plot_dir=plot_dir,
+        raw_acq_dir=raw_acq_dir,
     )
 
     raw_acq.plot_total_dynamic_spectrum(
@@ -232,13 +251,13 @@ def plot_summed_spectrum(
     
     # If email is provided, send email
     if len(email) != 0:
-        if username is not None or app_password is not None:
+        if username is not None and app_password is not None:
             files = [plot_name]
             email_text = 'Greetings,\n\nYou are subscribed to the CHIME/FRB GBO outrigger data quality emails. Attached is the following:\n\t(1) A PDF containing a dynamic spectrum of the raw data coming out of the analog-to-digital converters attached to each feed. Specifically, this is the total dynamic spectrum summed over each feed.\n If you have any questions about the contents of this email, feel free to reach out to CHIME/FRB grad student Bridget Andersen at bridgetcandersen@gmail.com.\n Cheers,\n\n Bridget Andersen'
             subject = 'CHIME/FRB Outriggers Data Quality'
             send_email(subject, email_text, username, list(email), app_password, files=files)
         else:
-            print("Cannot send email without Gmail username/password. Please specify the username/password at the beginning of raw_acq_cli.py.")
+            print("Cannot send email without RAW_ACQ_EMAIL_USERNAME and RAW_ACQ_EMAIL_APP_PASSWORD.")
 
     # Remove plot if it shouldn't be saved...
     if not save_plot:

--- a/raw_acq_diagnostics/raw_acq_diagnostics.py
+++ b/raw_acq_diagnostics/raw_acq_diagnostics.py
@@ -185,24 +185,19 @@ class RawAcq(object):
         self,
         filenames: np.ndarray = None,
         dates: np.ndarray = None,
-        plot_dir: str = '/home//bandersen/raw_acq_diagnostics/',
-        raw_acq_dir: str = '/home/masuilab/data/raw_acq/',
+        plot_dir: str = '.',
+        raw_acq_dir: str = None,
     ):
         """ Instantiates a RawAcq object for a given set of files or date range. You must define
             one or the other!
         """
-        self.raw_acq_dir = raw_acq_dir
-        self.plot_dir = plot_dir
+        self.raw_acq_dir = None if raw_acq_dir is None else os.fspath(raw_acq_dir)
+        self.plot_dir = os.fspath(plot_dir)
         
         # Check to make sure parameters are in the right form
-        if not os.path.exists(plot_dir):
+        if not os.path.exists(self.plot_dir):
             raise RawAcqException(
-                "Output directory does not exist: {}".format(plot_dir)
-            )
-        
-        if not os.path.exists(raw_acq_dir):
-            raise RawAcqException(
-                "Raw acquisition directory does not exist: {}".format(raw_acq_dir)
+                "Output directory does not exist: {}".format(self.plot_dir)
             )
         
         if ((filenames is None) and (dates is None)) or \
@@ -212,6 +207,16 @@ class RawAcq(object):
             )
             
         if dates is not None:
+            if self.raw_acq_dir is None:
+                raise RawAcqException(
+                    "raw_acq_dir is required when loading by date."
+                )
+            if not os.path.exists(self.raw_acq_dir):
+                raise RawAcqException(
+                    "Raw acquisition directory does not exist: {}".format(
+                        self.raw_acq_dir
+                    )
+                )
             if len(dates) != 2 or \
                type(dates[0]) != datetime.datetime or \
                type(dates[1]) != datetime.datetime:
@@ -248,7 +253,7 @@ class RawAcq(object):
             An array of len=2 with UTC dates [start_date, end_date] indicating which filenames should be
             loaded into the RawAcq object for plotting purposes
         """
-        utc = pytz.timezone('UTC')
+        utc = pytz.utc
         # If dates provided, find filenames within those dates
         if dates is not None:
             start_date = dates[0]
@@ -265,41 +270,66 @@ class RawAcq(object):
             # {isotime}_{corr_name}_rawadc, 
             # where isotime is the time & date in ISO format,
             # and corr_name is a descriptive name for the run
-            raw_acq_dirs = glob.glob("{}/*_gbo_rawadc*".format(self.raw_acq_dir))
+            raw_acq_dirs = glob.glob(os.path.join(self.raw_acq_dir, "*_gbo_rawadc*"))
             raw_acq_dirs.sort(key=os.path.getmtime)
             raw_acq_dirs = np.array(raw_acq_dirs)
+            if len(raw_acq_dirs) == 0:
+                raise RawAcqException(
+                    "No raw acquisition directories found in: {}".format(
+                        self.raw_acq_dir
+                    )
+                )
             raw_acq_start_dates = np.array([dateutil.parser.isoparse(re.split("/|_", d)[-3]) for d in raw_acq_dirs])
             # TODO: Update this to be faster for more recent data? Will be important once we have been operating
             # for a while.
             inds = np.where((raw_acq_start_dates <= end_date))[0] # (raw_acq_start_dates >= start_date) & 
+            if len(inds) == 0:
+                raise RawAcqException(
+                    "No raw acquisition directories begin before the requested end date."
+                )
             if inds[0] - 1 >= 0:
                 inds = np.concatenate(([inds[0]-1], inds))
 
             # Then filter by files in those directories
             files = []
             for d in raw_acq_dirs[inds]:
-                fs = glob.glob("{}/*h5".format(d))
-                files = np.concatenate((files, fs))
-            files = files.tolist()
+                files.extend(glob.glob(os.path.join(d, "*.h5")))
+            if len(files) == 0:
+                raise RawAcqException("No HDF5 acquisition files found for the requested dates.")
             files.sort(key=os.path.getmtime)
-            file_dates = np.array([utc.localize(datetime.datetime.utcfromtimestamp((os.path.getmtime(f)))) for f in files])
+            file_dates = np.array([
+                datetime.datetime.fromtimestamp(os.path.getmtime(f), tz=utc)
+                for f in files
+            ])
             inds = np.where((file_dates >= start_date) & (file_dates <= end_date))[0]
             if len(inds) == 0:
                 time_delta = datetime.timedelta(hours=1)
                 inds = np.where((file_dates >= start_date-time_delta) & (file_dates <= end_date+time_delta))[0]
-            inds = np.concatenate((inds,[inds[-1]+1]))
-            inds = np.concatenate(([inds[0]-1],inds))
+            if len(inds) == 0:
+                raise RawAcqException("No HDF5 acquisition files overlap the requested dates.")
+            neighbor_inds = [max(inds[0] - 1, 0), *inds, min(inds[-1] + 1, len(files) - 1)]
+            inds = np.unique(neighbor_inds)
             filenames = np.array(files)[inds]
         
         # Read in filenames and populate data and metadata
         filenames = np.array(filenames).tolist()
         filenames.sort(key=os.path.getmtime)
-        file_dates = np.array([utc.localize(datetime.datetime.utcfromtimestamp((os.path.getmtime(f)))) for f in filenames])
+        file_dates = np.array([
+            datetime.datetime.fromtimestamp(os.path.getmtime(f), tz=utc)
+            for f in filenames
+        ])
         log.info("Reading in filenames corresponding to the following times:")
         for jj in range(len(filenames)):
             log.info("{} : {}".format(file_dates[jj].strftime("%Y-%m-%d %H:%M:%S"), filenames[jj]))
         
-        for ii, fn in enumerate(filenames):
+        crates_parts = []
+        slots_parts = []
+        inputs_parts = []
+        ctimes_parts = []
+        fpga_counts_parts = []
+        timestream_parts = []
+
+        for fn in filenames:
             # Skip any filenames that are still locked (actively being written)
             try:
                 f_h5 = h5py.File(fn, 'r')
@@ -330,26 +360,35 @@ class RawAcq(object):
             # Note that crate, fpga_slot, sma_input, ctime will have len=npackets
             
             f_h5.close()
-            
-            # Concatenate together timestream and metadata arrays
-            if ii == 0:
-                crates = crate
-                slots = fpga_slot
-                inputs = sma_input
-                ctimes = ctime
-                fpga_counts = fpga_count
-                timestream = timestream_fn
-            else:
-                crates = np.concatenate((crates, crate))
-                slots = np.concatenate((slots, fpga_slot))
-                inputs = np.concatenate((inputs, sma_input))
-                ctimes = np.concatenate((ctimes, ctime))
-                fpga_counts = np.concatenate((fpga_counts, fpga_count))
-                timestream = np.concatenate((timestream, timestream_fn))
+
+            crates_parts.append(crate)
+            slots_parts.append(fpga_slot)
+            inputs_parts.append(sma_input)
+            ctimes_parts.append(ctime)
+            fpga_counts_parts.append(fpga_count)
+            timestream_parts.append(timestream_fn)
+
+        if not timestream_parts:
+            raise RawAcqException("None of the selected acquisition files could be read.")
+
+        crates = np.concatenate(crates_parts)
+        slots = np.concatenate(slots_parts)
+        inputs = np.concatenate(inputs_parts)
+        ctimes = np.concatenate(ctimes_parts)
+        fpga_counts = np.concatenate(fpga_counts_parts)
+        timestream = np.concatenate(timestream_parts)
         
         # Complete one more time filter for time at the frame level (30 second resolution)
-        frame_datetimes = np.array([pytz.utc.localize(datetime.datetime.fromtimestamp(ctime)) for ctime in ctimes])
-        inds = np.where((frame_datetimes >= start_date) & (frame_datetimes <= end_date))[0]
+        frame_datetimes = np.array([
+            datetime.datetime.fromtimestamp(ctime, tz=utc)
+            for ctime in ctimes
+        ])
+        if dates is None:
+            inds = np.arange(len(ctimes))
+        else:
+            inds = np.where((frame_datetimes >= start_date) & (frame_datetimes <= end_date))[0]
+        if len(inds) == 0:
+            raise RawAcqException("No acquisition frames overlap the requested dates.")
         
         # Save the final arrays in the object
         self.crates = crates[inds]
@@ -361,16 +400,22 @@ class RawAcq(object):
         
         # Calculate and save some metadata
         # ctime timestamp of first frame in this file
-        self.start_time = utc.localize(datetime.datetime.fromtimestamp(self.ctimes[0]))
+        self.start_time = datetime.datetime.fromtimestamp(self.ctimes[0], tz=utc)
         # ctime timestamp of last frame in this file
-        self.end_time = utc.localize(datetime.datetime.fromtimestamp(self.ctimes[-1]))
-        # Figure out the frame time for each unique frame, and, therefore, how many frames were saved
-        uniq_fpga_count, iuniq, itime = np.unique(self.fpga_counts, return_index=True, return_inverse=True)
+        self.end_time = datetime.datetime.fromtimestamp(self.ctimes[-1], tz=utc)
+        # A counter can reset or repeat across files, so identify frames by the
+        # timestamp/counter pair and retain their original read order.
+        frame_keys = np.rec.fromarrays(
+            (self.ctimes, self.fpga_counts),
+            names=("ctime", "fpga_count"),
+        )
+        _, iuniq = np.unique(frame_keys, return_index=True)
+        iuniq.sort()
         self.ctime_frames = self.ctimes[iuniq]
         self.num_crates = np.max(self.crates) + 1
         self.num_slots = np.max(self.slots) + 1
         self.num_inputs = np.max(self.inputs) + 1
-        self.num_frames = len(self.ctime_frames) + 1
+        self.num_frames = len(self.ctime_frames)
       
     
     def get_timestream_for_input(self, crate_number : int, slot_number : int, input_number : int):
@@ -614,7 +659,7 @@ class RawAcq(object):
         else:
             plot_name = "{}/{}.pdf".format(
                 self.plot_dir,
-                plot_name,
+                plot_filename,
             )
         log.info("Outputting plot to: {}".format(plot_name))
         p = PdfPages(plot_name)
@@ -847,15 +892,15 @@ class RawAcq(object):
         ctimes_all = []
         fft_all = []
 
+        bad_input_set = {tuple(map(int, bad_input)) for bad_input in bad_inputs}
         for ii in inputs:
             crate_number = ii[0]
             slot_number = ii[1]
             input_number = ii[2]
-            
-            for bi in BAD_INPUTS:
-                if bi[0] == ii[0] and bi[1] == ii[1] and bi[2] == ii[2]:
-                    log.info("Skipping bad input {}".format(ii))
-                    continue
+
+            if tuple(map(int, ii)) in bad_input_set:
+                log.info("Skipping bad input {}".format(ii))
+                continue
 
             fft, _ = self.calc_fft(crate_number, slot_number, input_number)
             _, ctimes, _ = self.get_timestream_for_input(crate_number, slot_number, input_number)
@@ -880,7 +925,10 @@ class RawAcq(object):
         fft_all_flagged = fft_all
         log.info("Sum dynamic spectrum over all inputs")
         fft_all_summed = np.sum(fft_all_flagged, axis=0)
-        ctimes_all_averaged = np.array([pytz.utc.localize(datetime.datetime.fromtimestamp(ctime)) for ctime in np.mean(ctimes_all, axis=0)])
+        ctimes_all_averaged = np.array([
+            datetime.datetime.fromtimestamp(ctime, tz=pytz.utc)
+            for ctime in np.mean(ctimes_all, axis=0)
+        ])
         start_time = self.start_time
         end_time = self.end_time
 
@@ -1052,7 +1100,7 @@ class RawAcq(object):
         else:
             plot_name = "{}/{}.pdf".format(
                 self.plot_dir,
-                plot_name,
+                plot_filename,
             )
         log.info("Outputting plot to: {}".format(plot_name))
         p = PdfPages(plot_name)
@@ -1071,7 +1119,10 @@ class RawAcq(object):
             fft, _ = self.calc_fft(crate_number, slot_number, input_number)
             _, ctimes, _ = self.get_timestream_for_input(crate_number, slot_number, input_number)
             
-            ctimes_dates = np.array([pytz.utc.localize(datetime.datetime.fromtimestamp(ctime)) for ctime in ctimes])
+            ctimes_dates = np.array([
+                datetime.datetime.fromtimestamp(ctime, tz=pytz.utc)
+                for ctime in ctimes
+            ])
             start_time = self.start_time
             end_time = self.end_time
             # Note: will be the same for determining transit time regardless of site, 
@@ -1273,7 +1324,8 @@ def plot_maintenance_vs_nonmaintenance_timeseries(
     plot_filename = None,
     bad_inputs = BAD_INPUTS,
     figsize = (11,5),
-    plot_dir = './'
+    plot_dir = './',
+    raw_acq_dir = None,
 ):
     """ This function creates plots showing a band-averaged and input-averaged 24 hr timeseries of 
         the raw acq data, with two panels splitting between maintenance and non-maintenance days. 
@@ -1298,6 +1350,8 @@ def plot_maintenance_vs_nonmaintenance_timeseries(
             The name of the plot file, if you want it to be different than default
         bad_inputs : list of int
             An Nx3 list specifying bad inputs to avoid. Each N entry is a coordinate: [crate, slot, input]
+        raw_acq_dir : str
+            Directory containing the dated raw-acquisition subdirectories.
         
         Outputs
         -------
@@ -1333,7 +1387,7 @@ def plot_maintenance_vs_nonmaintenance_timeseries(
     else:
         plot_name = "{}/{}.pdf".format(
             plot_dir,
-            plot_name,
+            plot_filename,
         )
 
     log.info("Flagging bad inputs")
@@ -1342,13 +1396,11 @@ def plot_maintenance_vs_nonmaintenance_timeseries(
     slot_numbers = np.arange(16)
     inputs = np.array(list(itertools.product(crate_numbers, slot_numbers, input_numbers)), dtype=int)
     inputs_flagged = []
+    bad_input_set = {tuple(map(int, bad_input)) for bad_input in bad_inputs}
     for ii in inputs:
-        bad_input = False
-        for bi in BAD_INPUTS:
-            if bi[0] == ii[0] and bi[1] == ii[1] and bi[2] == ii[2]:
-                log.info("Flagging bad input {}".format(ii))
-                bad_input = True
-        if not bad_input:
+        if tuple(map(int, ii)) in bad_input_set:
+            log.info("Flagging bad input {}".format(ii))
+        else:
             inputs_flagged.append(ii)
     inputs = np.array(inputs_flagged)
     
@@ -1367,7 +1419,7 @@ def plot_maintenance_vs_nonmaintenance_timeseries(
             start_date_utc,
             end_date_utc,
         ])
-        raw_acq = RawAcq(dates=dates)
+        raw_acq = RawAcq(dates=dates, raw_acq_dir=raw_acq_dir)
 
         log.info("Calculating {} for all inputs on dates {} to {}".format(plot_types, dates[0].strftime("%Y-%m-%d %H:%M:%S"), dates[1].strftime("%Y-%m-%d %H:%M:%S")))
         ts_inputs = {}
@@ -1556,10 +1608,17 @@ def main():
         end_date_utc,
     ])
 
+    raw_acq_dir = os.environ.get("RAW_ACQ_DIR")
+    if raw_acq_dir is None:
+        raise RawAcqException(
+            "Set RAW_ACQ_DIR before running raw_acq_diagnostics.py directly."
+        )
+
     # Read in the data
-    raw_acq = RawAcq(dates=dates)
+    raw_acq = RawAcq(dates=dates, raw_acq_dir=raw_acq_dir)
 
     # Make PDFs showing individual dynamic spectra for all inputs for the given time period
+    crate_number = 0
     for slot in range(16):
         raw_acq.plot_slot_dynamic_spectrum_summary(crate_number, slot, mask_rfi=False, mask_sun=False, ds_time_factor=1, ds_freq_factor=1, save_plot=True)
 

--- a/rawice.py
+++ b/rawice.py
@@ -11,7 +11,32 @@ import glob
 import os.path
 from scipy.signal import get_window
 import sys
+import warnings
 from scipy.optimize import curve_fit
+
+
+class _LegacyAnalysisFactory:
+    """Bind nested analysis helpers to an acquisition instance.
+
+    Access through an instance (``acq.check_input(...)``) uses that instance.
+    Access through the class (``raw_acq.check_input(...)``), which is used by
+    older notebooks, uses the most recently loaded acquisition.
+    """
+
+    def __init__(self, analysis_class_name):
+        self.analysis_class_name = analysis_class_name
+
+    def __get__(self, instance, owner):
+        def create_analysis(*args, **kwargs):
+            acquisition = instance if instance is not None else owner._latest_instance
+            if acquisition is None:
+                raise RuntimeError(
+                    "Load a raw_acq file before creating an analysis helper."
+                )
+            analysis_class = getattr(owner, self.analysis_class_name)
+            return analysis_class(acquisition, *args, **kwargs)
+
+        return create_analysis
 
 
 def progressbar(it, prefix="", size=60, out=sys.stdout):
@@ -43,16 +68,16 @@ def progressbar(it, prefix="", size=60, out=sys.stdout):
     
     DONE reading files and getting delays
     
-    A possible error:
-    Getting a 'divide by zero' error within the progressbar() function when calling analyse_maser()
-        Make sure that the raw acq folder variable has a '/' at the end. 
-        raw_acq_folder = "home/users/path/acq" will yield this error
-        raw_acq_folder = "home/users/path/acq/" will not yield this error
+    Empty iterables complete without attempting to divide by zero.
         
     '''
     count = len(it)
+    if count == 0:
+        print(f"Done {prefix}\n", flush=True, file=out)
+        return
+
     def show(j):
-        x = int(size*j/count) ### dividing by 0 here
+        x = int(size*j/count)
         print("{}[{}{}] {}/{}".format(prefix, u"#"*x, "."*(size-x), j, count), end='\r', file=out, flush=True)
     show(0)
     for i, item in enumerate(it):
@@ -83,6 +108,17 @@ class raw_acq:
         calculate values and assign them to this object.
     
     '''
+    _latest_instance = None
+    _legacy_state_fields = (
+        "timestream",
+        "timestamp",
+        "crate",
+        "slot",
+        "adc_input",
+        "start_time",
+        "end_time",
+    )
+
     def __init__(self, raw_acq_file, diagnostics = False):
         '''
         
@@ -113,22 +149,42 @@ class raw_acq:
         index_map = self.hdf5['index_map']
         im_timestream = index_map['timestream'][:]
         #im_snapshot = index_map['snapshot'][:]
-        adc_input = np.hstack(self.hdf5['adc_input'][:])
-        crate = np.hstack(self.hdf5['crate'][:])
-        slot = np.hstack(self.hdf5['slot'][:])
-        timestamp = np.hstack(self.hdf5['timestamp'][:])
+        adc_input_data = self.hdf5['adc_input'][:]
+        crate_data = self.hdf5['crate'][:]
+        slot_data = self.hdf5['slot'][:]
+        timestamp_data = self.hdf5['timestamp'][:]
         timestream = self.hdf5['timestream'][:]
+        if any(
+            array.size == 0
+            for array in (adc_input_data, crate_data, slot_data, timestamp_data, timestream)
+        ):
+            self.hdf5.close()
+            raise ValueError(
+                f"Acquisition file {os.fspath(self.file)!r} contains no frames."
+            )
+        adc_input = np.hstack(adc_input_data)
+        crate = np.hstack(crate_data)
+        slot = np.hstack(slot_data)
+        timestamp = np.hstack(timestamp_data)
         adc_stream_len = timestream.shape[-1]
 
         fpga_counts = np.hstack(timestamp['fpga_count'])
         ctime = np.hstack(timestamp['ctime'])
-        start_time = datetime.datetime.fromtimestamp(ctime[0]).isoformat()
-        end_time = datetime.datetime.fromtimestamp(ctime[-1]).isoformat()
+        start_time = datetime.datetime.fromtimestamp(
+            ctime[0], tz=datetime.timezone.utc
+        ).isoformat()
+        end_time = datetime.datetime.fromtimestamp(
+            ctime[-1], tz=datetime.timezone.utc
+        ).isoformat()
 
-        adc_record_fpga_count_index = np.where(np.roll(fpga_counts,1)!=fpga_counts)[0]
-        adc_record_ctime_index = np.where(np.roll(ctime,1)!=ctime)[0]
+        adc_record_fpga_count_index = np.flatnonzero(
+            np.r_[True, fpga_counts[1:] != fpga_counts[:-1]]
+        )
+        adc_record_ctime_index = np.flatnonzero(
+            np.r_[True, ctime[1:] != ctime[:-1]]
+        )
         adc_record_fpga_count = fpga_counts[adc_record_fpga_count_index]
-        adc_record_ctime = fpga_counts[adc_record_ctime_index]
+        adc_record_ctime = ctime[adc_record_ctime_index]
         self.fpga_counts_between_raw_adc_capture = np.diff(adc_record_fpga_count)
         self.time_between_adc_capture = np.unique(self.fpga_counts_between_raw_adc_capture*2.56e-6)
         
@@ -136,15 +192,36 @@ class raw_acq:
         self.num_inputs = np.max(adc_input) + 1
         self.num_crates = np.max(crate) + 1
         self.num_slots = np.max(slot) + 1
-        self.num_timestamps = adc_record_fpga_count.shape[0] + 1
-        raw_acq.timestream = timestream.astype(int)
-        raw_acq.timestamp = timestamp
-        raw_acq.crate = crate
-        raw_acq.slot = slot
-        raw_acq.adc_input = adc_input
-        raw_acq.start_time = start_time
-        raw_acq.end_time = end_time
+        self.num_timestamps = adc_record_fpga_count.shape[0]
+        self.timestream = timestream.astype(int)
+        self.timestamp = timestamp
+        self.crate = crate
+        self.slot = slot
+        self.adc_input = adc_input
+        self.start_time = start_time
+        self.end_time = end_time
+        self.adc_record_ctime = adc_record_ctime
+        self._publish_legacy_class_state()
         print("Loaded raw acq HDF5 file ... \r")
+
+    def _publish_legacy_class_state(self):
+        """Keep historical class-level access pointed at the newest file.
+
+        New code should read data from the acquisition instance. The aliases
+        remain for notebooks that call ``raw_acq(file)`` and then inspect
+        ``raw_acq.timestream`` or call ``raw_acq.check_input(...)``.
+        """
+        acquisition_class = type(self)
+        acquisition_class._latest_instance = self
+        for field in self._legacy_state_fields:
+            setattr(acquisition_class, field, getattr(self, field))
+
+    def _input_mask(self, crate_number, slot_number, input_number):
+        return (
+            (self.crate == crate_number)
+            & (self.slot == slot_number)
+            & (self.adc_input == input_number)
+        )
        
     def diagostics(self):
         '''
@@ -167,8 +244,8 @@ class raw_acq:
         print(f"Timestamping_warning: {self.hdf5.attrs['timestamping_warning'].decode()}")
         print()
 
-        print(f"ctime Timestamp of first raw_adc frame: {raw_acq.start_time}")
-        print(f"ctime Timestamp of last raw_adc frame: {raw_acq.end_time}")
+        print(f"ctime Timestamp of first raw_adc frame: {self.start_time}")
+        print(f"ctime Timestamp of last raw_adc frame: {self.end_time}")
         print()
         
         plt.figure(figsize=(15,3))
@@ -180,7 +257,7 @@ class raw_acq:
         plt.title("Time since last adc capture")
         
         
-    class check_input:
+    class _CheckInput:
         '''
         
             Input: a single array corresponding to the input on the ICE board [crate number, slot number, input number]
@@ -191,7 +268,7 @@ class raw_acq:
             that holds information for a single input. 
             
         '''
-        def __init__(single_inp, input_to_check):
+        def __init__(single_inp, acquisition, input_to_check):
             '''
             
             Input: a single array corresponding to the input on the ICE board [crate number, slot number, input number]
@@ -202,6 +279,7 @@ class raw_acq:
             
             '''
             print(f"Checking input {input_to_check} ... \r")
+            single_inp.acquisition = acquisition
             single_inp.input_to_check = input_to_check
             single_inp.get_timestream_for_input()
             single_inp.get_single_input_rms()
@@ -222,25 +300,27 @@ class raw_acq:
             
             '''
             itc = single_inp.input_to_check
+            if len(itc) != 3:
+                raise ValueError("input_to_check must be [crate, slot, input].")
+
+            crate_number = itc[0]
+            slot_number = itc[1]
             input_number = itc[2]
-            crate_number = itc[1]
-            slot_number = itc[0]
-            
-            single_inp.time_stamps = raw_acq.timestamp[np.intersect1d(
-                np.where(
-                    raw_acq.adc_input == input_number),
-                np.where(
-                    raw_acq.crate == crate_number),
-                np.where(
-                    raw_acq.slot == slot_number)
-            )]
-            single_inp.time_streams = raw_acq.timestream[np.intersect1d(
-                np.where(
-                    raw_acq.adc_input == input_number),
-                np.where(
-                    raw_acq.crate == crate_number),
-                np.where(
-                    raw_acq.slot == slot_number))]
+
+            acquisition = single_inp.acquisition
+            input_mask = acquisition._input_mask(
+                crate_number,
+                slot_number,
+                input_number,
+            )
+            if not np.any(input_mask):
+                raise ValueError(
+                    "No acquisition data found for "
+                    f"[crate={crate_number}, slot={slot_number}, input={input_number}]."
+                )
+
+            single_inp.time_stamps = acquisition.timestamp[input_mask]
+            single_inp.time_streams = acquisition.timestream[input_mask]
             input_id = {}
             input_id["crate"] = crate_number 
             input_id["slot"] = slot_number
@@ -363,8 +443,6 @@ class raw_acq:
             fig.show()
         
         def get_curve_fit(single_input):
-            xlist = [val for val in range(0+1, 2049)]
-            #xlist = [(float(val)*(1.25e-9)) for val in x]
             amp = []
             amp_error = []
             freq_stability = []
@@ -377,10 +455,11 @@ class raw_acq:
             
             #change the names so they make sense phase_err -> tau_err
             
-            for i in range(2048):
+            num_frames = single_input.time_streams.shape[0]
+            for i in range(num_frames):
                 #get each timestream for fitting
                 ylist = single_input.time_streams[i]
-                xlist = [val for val in range(0+1, len(xlist)+1)]
+                xlist = np.arange(1, len(ylist) + 1)
                 yerror = np.ones(len(xlist)) * 1/np.sqrt(12)
 
                 #fit the sine wave
@@ -427,9 +506,13 @@ class raw_acq:
             single_input.vert_err = vertical_error
             single_input.phase_err = phase_err   #change!
             
-            single_input.phase_unwrapped = np.unwrap(phase - phase[0])
+            phase_array = np.asarray(phase)
+            single_input.phase_unwrapped = np.unwrap(phase_array - phase_array[0])
+            # Preserve the historical calculation, which uses the stability
+            # from the final fit for every phase sample. Its scientific
+            # interpretation needs validation before changing that behavior.
             single_input.tau_shift = [(val/2/np.pi/(popt[1]*10e6)/1e-9) for val in single_input.phase_unwrapped]
-            for val in range(2048):
+            for val in range(num_frames):
                 if single_input.phase_err[val] > 1e7:
                     print(val)
             #why 10e6 and 1.25e-9
@@ -440,7 +523,7 @@ class raw_acq:
 
             #get the timestream plot ready
             ylist = single_input.time_streams[i]
-            xlist = [val for val in range(0+1, len(ylist)+1)]
+            xlist = np.arange(1, len(ylist) + 1)
             yerror = np.ones(len(xlist)) * 1/np.sqrt(12)
             
             #print(single_input.phase_err[i])
@@ -460,36 +543,38 @@ class raw_acq:
             #get avg of d, then do curve fit again with a set d value
             #save error to plot the b val with error bars  
             
+            fit_indices = np.arange(len(single_input.tau_shift))
             fig, ax = plt.subplots(figsize=(20,10))
             #ax.plot(xlist, tau_shift, '.')
-            ax.errorbar(xlist, single_input.tau_shift, yerr=single_input.tau_err, fmt=',', ecolor='orange')
+            ax.errorbar(fit_indices, single_input.tau_shift, yerr=single_input.tau_err, fmt=',', ecolor='orange')
             ax.set_title('Tau shift')
-            ax.set_ylabel('$\Delta$ $\tau$ (ns)')
+            ax.set_ylabel(r'$\Delta$ $\tau$ (ns)')
             
             fig, ax1 = plt.subplots(figsize=(20,10))
             #ax1.errorbar(xlist, single_input.freq_stability, yerr=single_input.freq_err, fmt='.', ecolor='orange')
-            ax1.plot(xlist, single_input.freq_stability, '.')
+            ax1.plot(fit_indices, single_input.freq_stability, '.')
             ax1.set_title('Frequency Stability')
             
             fig, ax2 = plt.subplots(figsize=(20,10))
             #ax2.errorbar(xlist, single_input.amp, yerr=single_input.amp_err, fmt='.', ecolor='orange')
-            ax2.plot(xlist, single_input.amp, '.')
+            ax2.plot(fit_indices, single_input.amp, '.')
             ax2.set_title('Amplitude')
             
                 
             
     
-    class check_iceboard:
+    class _CheckIceboard:
         """
             Check adc rms of all inputs of an iceboard of a given crate and slot from a singel raw_acq file
         """
-        def __init__(iceboard, crate, slot): #, time_slice):
+        def __init__(iceboard, acquisition, crate, slot): #, time_slice):
             '''
             
             
             
             '''
             #iceboard.time_slice = time_slice
+            iceboard.acquisition = acquisition
             iceboard.crate = crate
             iceboard.slot = slot
             iceboard.full_acq_capture_diagnostic()
@@ -503,13 +588,17 @@ class raw_acq:
             ant_std = np.zeros(16)
             ant_rms = np.zeros(16)
             plt.figure(figsize=(15,8))
-            plt.suptitle(f"total adc_rms of (crate,slot){iceboard.crate}{iceboard.slot} between {raw_acq.start_time} and {raw_acq.end_time}")
+            acquisition = iceboard.acquisition
+            plt.suptitle(f"total adc_rms of (crate,slot){iceboard.crate}{iceboard.slot} between {acquisition.start_time} and {acquisition.end_time}")
             #print("\n\n")
             #print("(crate,slot,input),rms,log2std")
             for i in range(16):
-                inp0 = np.where(raw_acq.adc_input[:] == i)[0]
-                ant0_data = raw_acq.timestream[:][inp0]
-                ant0_data = ant0_data[:]
+                input_mask = acquisition._input_mask(
+                    iceboard.crate,
+                    iceboard.slot,
+                    i,
+                )
+                ant0_data = acquisition.timestream[input_mask]
                 #ant_rms[i] = np.sqrt(np.mean(ant0_data)**2)
                 #ant_std[i] =  np.log2(np.std(ant0_data))
                 #print(f"({check_crate},{check_slot},{i}),{ant_rms[i]:1.3f},{ant_std[i]:1.3f}")
@@ -519,6 +608,9 @@ class raw_acq:
                 plt.title(f'input: {i}')
                 plt.tight_layout()
             plt.show()
+
+    check_input = _LegacyAnalysisFactory("_CheckInput")
+    check_iceboard = _LegacyAnalysisFactory("_CheckIceboard")
 
             
 class analyse_maser: 
@@ -547,27 +639,37 @@ class analyse_maser:
         
         
         '''
-        files = glob.glob(self.folder_path + "*[!.lock]")
-        files.sort()
-        files = files[:self.num_files]
+        files = _list_acquisition_files(self.folder_path)
+        if self.num_files is not None:
+            files = files[:self.num_files]
+        if not files:
+            raise FileNotFoundError(
+                f"No acquisition files found in {os.path.abspath(self.folder_path)!r}."
+            )
+
         print(*files, sep = "\n")
         taus = []
         delays = []
         angles = []
-        num_files = len(files) ### this is zero
-        #calling progressbar with it=0 so that when we initialize count = 0, we divide by 0 (in x)
-        input_to_check = self.maser_input            
+        num_files = len(files)
+        input_to_check = self.maser_input
         for i in progressbar(range(num_files), "Computing Delay: ", 80):
             file_name = files[i]
             try:
-                raw_acq(file_name)
-            except OSError: 
-                pass
-            maser = raw_acq.check_input(input_to_check)
+                acquisition = raw_acq(file_name)
+            except (OSError, KeyError, ValueError) as error:
+                warnings.warn(f"Skipping unreadable acquisition file {file_name!r}: {error}")
+                continue
+            maser = acquisition.check_input(input_to_check)
             maser.inspect_maser()
             taus.append(maser.time_fpga_count)
             delays.append(maser.tau)
             angles.append(maser.angles)
+
+        if not taus:
+            raise OSError(
+                f"No readable acquisition files were found in {os.path.abspath(self.folder_path)!r}."
+            )
             
         self.fpgatime = np.concatenate(taus, axis = 0)
         self.angles = np.concatenate(angles, axis = 0)
@@ -629,14 +731,38 @@ class analyse_maser:
         self.plt = plt
     
         
+def _list_acquisition_files(folder_path):
+    """Return regular, unlocked acquisition files in deterministic order.
+
+    Historical notebooks pass both directory names and wildcard patterns.
+    """
+    folder_path = os.fspath(folder_path)
+    if glob.has_magic(folder_path):
+        pattern = folder_path
+    elif os.path.isdir(folder_path):
+        pattern = os.path.join(folder_path, "*")
+    else:
+        pattern = folder_path
+    files = glob.glob(pattern)
+    return sorted(
+        file_path
+        for file_path in files
+        if os.path.isfile(file_path) and not file_path.lower().endswith(".lock")
+    )
+
+
 def get_newest_file(folder_path):
     '''
     
     
     
     '''
-    files = glob.glob(folder_path + "*[!.lock]")
-    newest_file = max(files, key=os.path.getctime)
+    files = _list_acquisition_files(folder_path)
+    if not files:
+        raise FileNotFoundError(
+            f"No acquisition files found in {os.path.abspath(folder_path)!r}."
+        )
+    newest_file = max(files, key=os.path.getmtime)
     return newest_file
 
 def get_second_newest_file(folder_path):
@@ -645,9 +771,12 @@ def get_second_newest_file(folder_path):
     
     
     '''
-    files = glob.glob(folder_path + "*[!.lock]")
-    newest_file = max(files, key=os.path.getctime)
+    files = _list_acquisition_files(folder_path)
+    if len(files) < 2:
+        raise FileNotFoundError(
+            f"Fewer than two acquisition files found in {os.path.abspath(folder_path)!r}."
+        )
+    newest_file = max(files, key=os.path.getmtime)
     files.remove(newest_file)
-    newest_file = max(files, key=os.path.getctime)
+    newest_file = max(files, key=os.path.getmtime)
     return newest_file
-

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements-diagnostics.txt
+
+pytest>=8.0

--- a/requirements-diagnostics.txt
+++ b/requirements-diagnostics.txt
@@ -1,0 +1,9 @@
+-r requirements.txt
+
+beautifulsoup4>=4.12
+chime-frb-constants==2020.12
+click>=8.1
+ephem>=4.1
+python-dateutil>=2.8
+pytz>=2023.3
+requests>=2.31

--- a/requirements-notebooks.txt
+++ b/requirements-notebooks.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+
+allantools>=2024.6
+jupyter>=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy>=1.22
+scipy>=1.8
+matplotlib>=3.5
+h5py>=3.8

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ.setdefault("MPLBACKEND", "Agg")

--- a/tests/test_raw_acq_diagnostics.py
+++ b/tests/test_raw_acq_diagnostics.py
@@ -1,0 +1,133 @@
+import datetime
+import sys
+import types
+
+import numpy as np
+from click.testing import CliRunner
+
+from test_rawice import write_acquisition
+
+
+if "ephem" not in sys.modules:
+    ephem = types.ModuleType("ephem")
+    ephem.Observer = lambda: types.SimpleNamespace(lat=None, long=None)
+    sys.modules["ephem"] = ephem
+
+if "chime_frb_constants" not in sys.modules:
+    constants = types.ModuleType("chime_frb_constants")
+    constants.CHIME_LATITUDE_DEG = 49.32
+    constants.CHIME_LONGITUDE_DEG = -119.62
+    sys.modules["chime_frb_constants"] = constants
+
+from raw_acq_diagnostics import raw_acq_diagnostics as diagnostics
+from raw_acq_diagnostics import raw_acq_cli
+
+
+def test_direct_filename_loading_uses_all_frames_and_utc(tmp_path):
+    filename = write_acquisition(tmp_path / "diagnostics.h5")
+    acquisition = diagnostics.RawAcq(
+        filenames=np.array([str(filename)]),
+        plot_dir=tmp_path,
+    )
+
+    assert len(acquisition.timestream) == 4
+    assert acquisition.num_frames == 2
+    assert acquisition.start_time.tzinfo is not None
+    assert acquisition.start_time.utcoffset() == datetime.timedelta(0)
+    assert acquisition.end_time.utcoffset() == datetime.timedelta(0)
+
+
+def test_frame_count_survives_counter_reset_between_files(tmp_path):
+    first = write_acquisition(tmp_path / "first.h5")
+    second = write_acquisition(tmp_path / "second.h5", ctime_offset=60)
+    acquisition = diagnostics.RawAcq(
+        filenames=np.array([str(first), str(second)]),
+        plot_dir=tmp_path,
+    )
+
+    assert acquisition.num_frames == 4
+    assert acquisition.ctime_frames.tolist() == [
+        1_700_000_000.0,
+        1_700_000_030.0,
+        1_700_000_060.0,
+        1_700_000_090.0,
+    ]
+
+
+def test_cli_rejects_incomplete_or_invalid_date_ranges(tmp_path):
+    runner = CliRunner()
+    incomplete = runner.invoke(
+        raw_acq_cli.cli,
+        ["plot-summed-spectrum", "--raw-acq-dir", str(tmp_path), "--start-time", "2024-01-01 00:00:00"],
+    )
+    invalid = runner.invoke(
+        raw_acq_cli.cli,
+        [
+            "plot-summed-spectrum",
+            "--raw-acq-dir",
+            str(tmp_path),
+            "--start-time",
+            "not-a-date",
+            "--end-time",
+            "also-not-a-date",
+        ],
+    )
+
+    assert incomplete.exit_code != 0
+    assert invalid.exit_code != 0
+    assert "provide both" in incomplete.output
+    assert "times must use" in invalid.output
+
+
+def test_summed_spectrum_honors_bad_inputs(monkeypatch):
+    acquisition = object.__new__(diagnostics.RawAcq)
+    acquisition.start_time = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+    acquisition.end_time = acquisition.start_time + datetime.timedelta(seconds=30)
+    acquisition.plot_dir = "."
+    calls = []
+
+    def calc_fft(crate, slot, input_number):
+        calls.append((crate, slot, input_number))
+        spectrum = np.ones((2, 1024))
+        return spectrum, np.ones(1024)
+
+    acquisition.calc_fft = calc_fft
+    acquisition.get_timestream_for_input = lambda *coordinates: (
+        np.ones((2, 2048)),
+        np.array([1_700_000_000.0, 1_700_000_030.0]),
+        np.array([100, 200]),
+    )
+    monkeypatch.setattr(diagnostics.pytz, "timezone", lambda zone: diagnostics.pytz.utc)
+    monkeypatch.setattr(diagnostics.plt, "close", lambda *args, **kwargs: None)
+
+    acquisition.plot_total_dynamic_spectrum(
+        mask_rfi=False,
+        mask_sun=False,
+        ds_time_factor=1,
+        ds_freq_factor=1,
+        save_plot=False,
+        bad_inputs=[[0, 0, 0]],
+    )
+
+    assert (0, 0, 0) not in calls
+    assert (0, 0, 1) in calls
+    assert len(calls) == 255
+
+
+def test_custom_plot_filenames_are_accepted(tmp_path):
+    acquisition = object.__new__(diagnostics.RawAcq)
+    acquisition.plot_dir = str(tmp_path)
+    acquisition.start_time = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+    acquisition.end_time = acquisition.start_time
+    acquisition.num_inputs = 0
+
+    acquisition.plot_input_summary_diagnostic(
+        inputs=np.empty((0, 3), dtype=int),
+        plot_types=[],
+        plot_filename="summary",
+    )
+    acquisition.plot_slot_dynamic_spectrum_summary(
+        0,
+        0,
+        plot_filename="slot-summary",
+    )

--- a/tests/test_rawice.py
+++ b/tests/test_rawice.py
@@ -1,0 +1,140 @@
+import os
+
+import h5py
+import numpy as np
+import pytest
+
+import rawice
+
+
+def write_acquisition(path, value_offset=0, ctime_offset=0):
+    records = [
+        (0, 1, 2, 100, 1_700_000_000.0, 11 + value_offset),
+        (0, 1, 3, 100, 1_700_000_000.0, 12 + value_offset),
+        (1, 0, 2, 100, 1_700_000_000.0, 13 + value_offset),
+        (0, 1, 2, 200, 1_700_000_030.0, 21 + value_offset),
+    ]
+    timestamp_dtype = np.dtype([("fpga_count", "<i8"), ("ctime", "<f8")])
+    timestamps = np.zeros((len(records), 1), dtype=timestamp_dtype)
+    timestamps[:, 0]["fpga_count"] = [record[3] for record in records]
+    timestamps[:, 0]["ctime"] = [record[4] + ctime_offset for record in records]
+
+    with h5py.File(path, "w") as output:
+        index_map = output.create_group("index_map")
+        index_map.create_dataset("timestream", data=np.arange(len(records)))
+        output.create_dataset("crate", data=np.array([[r[0]] for r in records]))
+        output.create_dataset("slot", data=np.array([[r[1]] for r in records]))
+        output.create_dataset("adc_input", data=np.array([[r[2]] for r in records]))
+        output.create_dataset("timestamp", data=timestamps)
+        output.create_dataset(
+            "timestream",
+            data=np.array([
+                np.full(2048, record[5], dtype=np.int16)
+                for record in records
+            ]),
+        )
+        output.attrs["archive_version"] = np.bytes_("test")
+        output.attrs["collection_server"] = np.bytes_("test")
+        output.attrs["git_version_tag"] = np.bytes_("test")
+        output.attrs["file_name"] = str(path)
+        output.attrs["data_type"] = np.bytes_("raw")
+        output.attrs["system_user"] = np.bytes_("pytest")
+        output.attrs["rawadc_version"] = 1
+        output.attrs["timestamping_warning"] = np.bytes_("")
+    return path
+
+
+def test_instance_state_and_legacy_class_access(tmp_path):
+    first = rawice.raw_acq(write_acquisition(tmp_path / "first.h5"))
+    first_values = first.timestream.copy()
+    second = rawice.raw_acq(write_acquisition(tmp_path / "second.h5", 100))
+
+    np.testing.assert_array_equal(first.timestream, first_values)
+    np.testing.assert_array_equal(rawice.raw_acq.timestream, second.timestream)
+
+    first_input = first.check_input([0, 1, 2])
+    latest_input = rawice.raw_acq.check_input([0, 1, 2])
+    np.testing.assert_array_equal(first_input.time_streams[:, 0], [11, 21])
+    np.testing.assert_array_equal(latest_input.time_streams[:, 0], [111, 121])
+
+    np.testing.assert_array_equal(first.adc_record_ctime, [1_700_000_000.0, 1_700_000_030.0])
+    assert first.num_timestamps == 2
+    assert first.start_time.endswith("+00:00")
+    assert first.end_time.endswith("+00:00")
+    first.hdf5.close()
+    second.hdf5.close()
+
+
+def test_input_coordinates_are_crate_slot_input(tmp_path):
+    acquisition = rawice.raw_acq(write_acquisition(tmp_path / "coordinates.h5"))
+
+    crate_zero_slot_one = acquisition.check_input([0, 1, 2])
+    crate_one_slot_zero = acquisition.check_input([1, 0, 2])
+
+    np.testing.assert_array_equal(crate_zero_slot_one.time_streams[:, 0], [11, 21])
+    np.testing.assert_array_equal(crate_one_slot_zero.time_streams[:, 0], [13])
+    assert acquisition._input_mask(0, 1, 2).tolist() == [True, False, False, True]
+    acquisition.hdf5.close()
+
+
+def test_curve_fit_uses_available_frame_count(monkeypatch, tmp_path):
+    acquisition = rawice.raw_acq(write_acquisition(tmp_path / "curve.h5"))
+    selected = acquisition.check_input([0, 1, 2])
+    selected.time_streams = np.ones((3, 8))
+    calls = []
+
+    def fake_curve_fit(*args, **kwargs):
+        phase = 1.0 + 0.1 * len(calls)
+        calls.append(phase)
+        return np.array([2.0, 1.0, phase, 0.0]), np.eye(4)
+
+    monkeypatch.setattr(rawice, "curve_fit", fake_curve_fit)
+    selected.get_curve_fit()
+
+    assert len(calls) == 3
+    assert len(selected.phase) == 3
+    np.testing.assert_allclose(selected.phase_unwrapped, [0.0, 0.1, 0.2])
+    acquisition.hdf5.close()
+
+
+def test_file_helpers_ignore_lock_files_and_handle_empty_directories(tmp_path):
+    lock_file = tmp_path / "capture.lock"
+    lock_file.write_text("locked")
+
+    with pytest.raises(FileNotFoundError):
+        rawice.get_newest_file(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        rawice.analyse_maser(tmp_path, [0, 0, 0])
+
+    first = tmp_path / "000001"
+    second = tmp_path / "000002"
+    first.write_text("first")
+    second.write_text("second")
+    os.utime(first, (1, 1))
+    os.utime(second, (2, 2))
+
+    assert rawice.get_newest_file(tmp_path) == str(second)
+    assert rawice.get_second_newest_file(tmp_path) == str(first)
+
+    nested = tmp_path / "run" / "raw_acq"
+    nested.mkdir(parents=True)
+    wildcard_file = nested / "000003"
+    wildcard_file.write_text("third")
+    pattern = str(tmp_path / "*" / "raw_acq" / "*")
+    assert rawice.get_newest_file(pattern) == str(wildcard_file)
+
+
+def test_empty_acquisition_has_a_clear_error(tmp_path):
+    filename = tmp_path / "empty.h5"
+    timestamp_dtype = np.dtype([("fpga_count", "<i8"), ("ctime", "<f8")])
+    with h5py.File(filename, "w") as output:
+        index_map = output.create_group("index_map")
+        index_map.create_dataset("timestream", data=np.empty(0, dtype=int))
+        output.create_dataset("crate", data=np.empty((0, 1), dtype=int))
+        output.create_dataset("slot", data=np.empty((0, 1), dtype=int))
+        output.create_dataset("adc_input", data=np.empty((0, 1), dtype=int))
+        output.create_dataset("timestamp", data=np.empty((0, 1), dtype=timestamp_dtype))
+        output.create_dataset("timestream", data=np.empty((0, 2048), dtype=np.int16))
+
+    with pytest.raises(ValueError, match="contains no frames"):
+        rawice.raw_acq(filename)


### PR DESCRIPTION
## Summary

- corrects acquisition instance state, coordinate selection, file discovery, frame accounting, UTC timestamps, curve-fit dimensions, and diagnostic output paths
- makes the diagnostics CLI portable and explicit about data paths and email credentials
- adds dependency sets, synthetic HDF5 regression tests, and a Python 3.9/3.11/3.12 test workflow
- completes the existing MIT license placeholder with the standard text while preserving contributor attribution
- documents the pinned DigitalNoiseSource snapshot and current limitations

## Verification

- 10 tests passed under a non-UTC host timezone
- legacy class-level and instance APIs exercised
- wildcard notebook paths and single-capture files exercised
- repeated FPGA counters across files preserve four ordered frames
- dependency dry-run, AST parse, diff check, protected-file scan, and prohibited-reference scan passed

## Review notes

The historical tau-shift convention is scientifically ambiguous and remains unchanged pending domain validation. No notebook or recorded-output content is changed. Merge the license completion only after WVURAIL confirms its authority or contributor consent for the historical work.